### PR TITLE
chore(test): support error responses in test server

### DIFF
--- a/graphql_test/operations.go
+++ b/graphql_test/operations.go
@@ -40,6 +40,37 @@ type Operation struct {
 	Response interface{}
 }
 
+// OperationError is a special type that brings together the properties that a
+// response error can include.
+type OperationError struct {
+	// Identifier helps identify the operation error in a request when coming through the Server.
+	// For example, if your operation looks like this:
+	//
+	//	error {
+	//		myOperation(foo: $foo) {
+	//			fieldOne
+	//			fieldTwo
+	//		}
+	//	}
+	//
+	// Then this field should be set to myOperation. It can also be more specific, a simple
+	// strings.Contains check occurs to match operations. A more specific example of a
+	// valid Identifier for the same operation given above would be myOperation(foo: $foo).
+	Identifier string
+
+	// Status represents the http status code that should be returned in the response
+	// whenever the server makes a match on OperationError.Identifier
+	Status int
+
+	// Error represents the error that should be returned in the response whenever
+	// the server makes a match on OperationError.Identifier
+	Error error
+
+	// Extensions represents the object that should be returned in the response
+	// as part of the api error whenever the server makes a match on OperationError.Extensions
+	Extensions interface{}
+}
+
 // --------------------------------------------------------- //
 // --- DEFAULT OPERATIONS ARE DEFINED BELOW THIS COMMENT --- //
 // --------------------------------------------------------- //

--- a/graphql_test/server.go
+++ b/graphql_test/server.go
@@ -75,7 +75,8 @@ func NewServer(t *testing.T, useDefaultOperations bool) *Server { //nolint:funle
 			return
 		}
 
-		if strings.HasPrefix(strings.TrimSpace(reqBody.Query), "mutation") {
+		switch {
+		case strings.HasPrefix(strings.TrimSpace(reqBody.Query), "mutation"):
 			for i := range s.mutations {
 				if strings.Contains(reqBody.Query, s.mutations[i].Identifier) {
 					if s.equalVariables(s.mutations[i].Variables, reqBody.Variables) {
@@ -84,7 +85,7 @@ func NewServer(t *testing.T, useDefaultOperations bool) *Server { //nolint:funle
 					}
 				}
 			}
-		} else if strings.HasPrefix(strings.TrimSpace(reqBody.Query), "query") {
+		case strings.HasPrefix(strings.TrimSpace(reqBody.Query), "query"):
 			for i := range s.queries {
 				if strings.Contains(reqBody.Query, s.queries[i].Identifier) {
 					if s.equalVariables(s.queries[i].Variables, reqBody.Variables) {
@@ -93,7 +94,7 @@ func NewServer(t *testing.T, useDefaultOperations bool) *Server { //nolint:funle
 					}
 				}
 			}
-		} else if strings.HasPrefix(strings.TrimSpace(reqBody.Query), "error") {
+		case strings.HasPrefix(strings.TrimSpace(reqBody.Query), "error"):
 			for i := range s.errors {
 				if strings.Contains(reqBody.Query, s.errors[i].Identifier) {
 					s.respondError(w, s.errors[i].Status, s.errors[i].Error, s.errors[i].Extensions)

--- a/graphql_test/web.go
+++ b/graphql_test/web.go
@@ -11,9 +11,9 @@ type Request struct {
 }
 
 type ResponseError struct {
-	Message    string   `json:"message"`
-	Path       []string `json:"path"`
-	Extensions struct{} `json:"extensions"`
+	Message    string      `json:"message"`
+	Path       []string    `json:"path"`
+	Extensions interface{} `json:"extensions"`
 }
 
 type Response struct {
@@ -21,18 +21,17 @@ type Response struct {
 	Errors []ResponseError `json:"errors,omitempty"`
 }
 
-func (s *Server) respondError(w http.ResponseWriter, status int, errs ...error) {
+func (s *Server) respondError(w http.ResponseWriter, status int, err error, extensions interface{}) {
 	s.t.Helper()
 
 	res := Response{
 		Data: nil,
 	}
 
-	for i := range errs {
-		res.Errors = append(res.Errors, ResponseError{
-			Message: errs[i].Error(),
-		})
-	}
+	res.Errors = append(res.Errors, ResponseError{
+		Message:    err.Error(),
+		Extensions: extensions,
+	})
 
 	w.WriteHeader(status)
 	if err := json.NewEncoder(w).Encode(res); err != nil {


### PR DESCRIPTION
## What this PR does / why we need it
`apiproxy` service needs to interpret flagship errors coming through giraffe in the `extensions` field of the `graphql error` type. This errors must be forwarded to comply with api v2 error definition. See more: https://outreach-io.atlassian.net/browse/VXP-4000

The changes in this proposal add a new operation `error` that can be registered in the test server to respond with a graphql error with a custom `extensions` field.  The value of the extensions interface is defined through the registered operation.

## Jira ID
[[ORES-1245]](https://outreach-io.atlassian.net/browse/ORES-1245)



[ORES-1245]: https://outreach-io.atlassian.net/browse/ORES-1245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ