### PR TITLE
fix: prevent race condition when marshalling cached operations

### DIFF
--- a/query.go
+++ b/query.go
@@ -575,8 +575,11 @@ func marshal(q interface{}, wrapper string, fields Fields) (string, error) { //n
 
 	// Check to see if this type has already been built.
 	if cachedOperation, hit := cache.Load(rt); hit {
-		// Cache hit, use the tree that was already built.
-		operation = cachedOperation.(*field)
+		// Cache hit, copy by value the tree that was already built.
+		// A copy is needed because the top level declaration name (primitive type)
+		// of the operation is re-assigned.
+		opReplica := *cachedOperation.(*field)
+		operation = &opReplica
 	} else {
 		// Not in cache, need to build by walking through the type and then store it in the
 		// cache for later use.


### PR DESCRIPTION
## What this PR does / why we need it
Re-bootstrapping with a recent version flags a race condition when running tests:

```shell
 :: Running go test (or_test)


  60ms . ·······················↷·································✖✖✖✖✖✖
       graphql_test

 63 tests, 1 skipped, 6 failures in 8.945s

=== Skipped
=== SKIP: . TestDoCustom (0.00s)
    do_test.go:51:

=== Failed
=== FAIL: . TestCustomOperationWithHeaders (0.01s)
    testing.go:1152: race detected during execution of test

=== FAIL: . TestQuery (0.01s)
    testing.go:1152: race detected during execution of test

=== FAIL: . TestCustomOperation (0.01s)
    testing.go:1152: race detected during execution of test

=== FAIL: . TestQueryWithHeaders (0.01s)
    testing.go:1152: race detected during execution of test

=== FAIL: . TestMutate (0.01s)
    testing.go:1152: race detected during execution of test

=== FAIL: . TestMutateWithHeaders (0.01s)
    testing.go:1152: race detected during execution of test

DONE 63 tests, 1 skipped, 6 failures in 8.963s
make: *** [test] Error 1
```

The issue occurs in the marshal method when multiple requests try to update the declaration name of the same cached operation https://github.com/getoutreach/goql/blob/6f72c1efa60eb971ac68dd8dbd602d133083d6e0/query.go#L636

The proposed fix copies the cached operation by value before it is updated. Since no other fields are updated during the marshalling process, there's no need make a deep copy (by reference).

## Jira ID

N/A

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->
