### PR TITLE
fix: tokenize fields based on node level

### DIFF
--- a/query_test.go
+++ b/query_test.go
@@ -128,6 +128,22 @@ fieldTwo
 }`,
 		},
 		{
+			Name: "WithArrayVariables",
+			Input: struct {
+				TestQuery struct {
+					FieldOne string
+					FieldTwo string
+				} `goql:"testQuery(id:$id<ID!>,list:$list<[List!]>)"`
+			}{},
+			Fields: nil,
+			ExpectedOutput: `query($id: ID!, $list: [List!]) {
+testQuery(id: $id, list: $list) {
+fieldOne
+fieldTwo
+}
+}`,
+		},
+		{
 			Name: "WithNameOverride",
 			Input: struct {
 				TestQuery struct {


### PR DESCRIPTION
## What this PR does / why we need it
Re-bootstrapping with a recent version flags a race condition when running tests:

```shell
 :: Running go test (or_test)


  60ms . ·······················↷·································✖✖✖✖✖✖
       graphql_test

 63 tests, 1 skipped, 6 failures in 8.945s

=== Skipped
=== SKIP: . TestDoCustom (0.00s)
    do_test.go:51:

=== Failed
=== FAIL: . TestCustomOperationWithHeaders (0.01s)
    testing.go:1152: race detected during execution of test

=== FAIL: . TestQuery (0.01s)
    testing.go:1152: race detected during execution of test

=== FAIL: . TestCustomOperation (0.01s)
    testing.go:1152: race detected during execution of test

=== FAIL: . TestQueryWithHeaders (0.01s)
    testing.go:1152: race detected during execution of test

=== FAIL: . TestMutate (0.01s)
    testing.go:1152: race detected during execution of test

=== FAIL: . TestMutateWithHeaders (0.01s)
    testing.go:1152: race detected during execution of test

DONE 63 tests, 1 skipped, 6 failures in 8.963s
make: *** [test] Error 1
```

The issue occurs in the marshal method when multiple requests try to update the declaration name of the same cached operation https://github.com/getoutreach/goql/blob/6f72c1efa60eb971ac68dd8dbd602d133083d6e0/query.go#L636

The proposed fix splits field tokenisation into different methods based on the level of the tree where the node is at. If the node is the root element, its declaration is not tokenised. Instead, the `wrapper` + `args from tokens` are passed to the writer. For the rest of the nodes, the tokenisation happens as usual.

## Jira ID

N/A

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->
