### PR TITLE
feat: Support fallback to json struct tag names

### DIFF
--- a/do.go
+++ b/do.go
@@ -116,11 +116,19 @@ func (c *Client) doStruct(ctx context.Context, operationType int, operation *Ope
 	// or mutation.
 	switch operationType {
 	case opQuery:
-		if queryStr, err = MarshalQuery(operation.OperationType, operation.Fields); err != nil {
+		if queryStr, err = MarshalQueryWithOptions(
+			operation.OperationType,
+			operation.Fields,
+			c.marshalOpts...,
+		); err != nil {
 			return err
 		}
 	case opMutation:
-		if queryStr, err = MarshalMutation(operation.OperationType, operation.Fields); err != nil {
+		if queryStr, err = MarshalMutationWithOptions(
+			operation.OperationType,
+			operation.Fields,
+			c.marshalOpts...,
+		); err != nil {
 			return err
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/getoutreach/gobox v1.73.2
 	github.com/google/go-cmp v0.5.9
 	github.com/pkg/errors v0.9.1
+	github.com/pmezard/go-difflib v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -5,3 +5,5 @@ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 gotest.tools/v3 v3.5.0 h1:Ljk6PdHdOhAb5aDMWXjDLMMhph+BpztA4v1QdqEW2eY=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/query.go
+++ b/query.go
@@ -153,6 +153,11 @@ func argsFromTokens(tokens []token) ([]string, error) {
 	// len(tokens) might be too big, but it's at least the max size it could be.
 	argsMap := make(map[string]string, len(tokens))
 
+	// we want to ensure these args are always in the same ouput order as they were in the input
+	// order (first appearance wins). By having a sorted order of the keys, we achieve stable
+	// marshal output
+	argOrder := []string{}
+
 	// Make sure we don't duplicate variables if they're used more than once, and if
 	// they are used more than once, validate their types are the same.
 	for _, token := range tokens {
@@ -164,13 +169,15 @@ func argsFromTokens(tokens []token) ([]string, error) {
 		}
 
 		argsMap[token.Arg] = token.Kind
+		argOrder = append(argOrder, token.Arg)
 	}
 
 	// This slice will contain values in the form of $<arg>: <Type> which can be joined
 	// with strings.Join(args, ", ") by the caller to achieve the correct format.
 	args := make([]string, 0, len(argsMap))
 
-	for arg, kind := range argsMap {
+	for _, arg := range argOrder {
+		kind := argsMap[arg]
 		args = append(args, fmt.Sprintf("$%s: %s", arg, kind))
 	}
 

--- a/query_test.go
+++ b/query_test.go
@@ -13,6 +13,7 @@ func TestMarshalQuery(t *testing.T) {
 		Name           string
 		Input          interface{}
 		Fields         Fields
+		Option         marshalOption
 		ExpectedOutput string // IfExpectedOutput == "", it implies an error.
 	}{
 		{
@@ -292,6 +293,36 @@ fieldABC
 }
 }`,
 		},
+		{
+			Name: "SimpleWithJSON",
+			Input: struct {
+				TestQuery struct {
+					FieldOne string `json:"differentField"`
+				}
+			}{},
+			Fields: nil,
+			Option: OptFallbackJSONTag,
+			ExpectedOutput: `query {
+testQuery {
+differentField
+}
+}`,
+		},
+		{
+			Name: "JSONOverriddenByGoqlTag",
+			Input: struct {
+				TestQuery struct {
+					FieldOne string `json:"differentField" goql:"overrideName"`
+				}
+			}{},
+			Fields: nil,
+			Option: OptFallbackJSONTag,
+			ExpectedOutput: `query {
+testQuery {
+overrideName
+}
+}`,
+		},
 	}
 
 	for _, test := range tt {
@@ -300,7 +331,7 @@ fieldABC
 		fn := func(t *testing.T) {
 			t.Parallel()
 
-			actualOutput, err := MarshalQuery(test.Input, test.Fields)
+			actualOutput, err := MarshalQueryWithOptions(test.Input, test.Fields, test.Option)
 			if err != nil {
 				if test.ExpectedOutput == "" {
 					// The error was expected, return without reporting anything.
@@ -338,6 +369,7 @@ func TestMarshalMutation(t *testing.T) {
 		Name           string
 		Input          interface{}
 		Fields         Fields
+		Option         marshalOption
 		ExpectedOutput string // IfExpectedOutput == "", it implies an error.
 	}{
 		{
@@ -601,6 +633,36 @@ fieldABC
 }
 }`,
 		},
+		{
+			Name: "SimpleWithJSON",
+			Input: struct {
+				TestQuery struct {
+					FieldOne string `json:"differentField"`
+				}
+			}{},
+			Fields: nil,
+			Option: OptFallbackJSONTag,
+			ExpectedOutput: `mutation {
+testQuery {
+differentField
+}
+}`,
+		},
+		{
+			Name: "JSONOverriddenByGoqlTag",
+			Input: struct {
+				TestQuery struct {
+					FieldOne string `json:"differentField" goql:"overrideName"`
+				}
+			}{},
+			Fields: nil,
+			Option: OptFallbackJSONTag,
+			ExpectedOutput: `mutation {
+testQuery {
+overrideName
+}
+}`,
+		},
 	}
 
 	for _, test := range tt {
@@ -609,7 +671,7 @@ fieldABC
 		fn := func(t *testing.T) {
 			t.Parallel()
 
-			actualOutput, err := MarshalMutation(test.Input, test.Fields)
+			actualOutput, err := MarshalMutationWithOptions(test.Input, test.Fields, test.Option)
 			if err != nil {
 				if test.ExpectedOutput == "" {
 					// The error was expected, return without reporting anything.

--- a/query_test.go
+++ b/query_test.go
@@ -3,89 +3,9 @@ package goql
 import (
 	"strings"
 	"testing"
-	"unicode/utf8"
+
+	"github.com/pmezard/go-difflib/difflib"
 )
-
-// computeLevenshteinDistance computes the levenshtein distance between the two
-// strings passed as an argument. The return value is the levenshtein distance.
-func computeLevenshteinDistance(a, b string) int {
-	// Custom local min function, since math.Min takes float64
-	min := func(a, b uint16) uint16 {
-		if a < b {
-			return a
-		}
-		return b
-	}
-
-	// If a is empty, the distance is the length of b.
-	if a == "" {
-		return utf8.RuneCountInString(b)
-	}
-
-	// If b is empty, the distance is the length of a.
-	if b == "" {
-		return utf8.RuneCountInString(a)
-	}
-
-	// If the two strings are equal there is no need to computer the distance, it will
-	// be 0.
-	if a == b {
-		return 0
-	}
-
-	s1 := []rune(a)
-	s2 := []rune(b)
-
-	// Swap to save on memory complexity: O(min(a,b)) instead of O(a)
-	if len(s1) > len(s2) {
-		s1, s2 = s2, s1
-	}
-	lenS1 := len(s1)
-	lenS2 := len(s2)
-
-	// init the row
-	x := make([]uint16, lenS1+1)
-
-	// Start from 1 because index 0 is already 0.
-	for i := 1; i < len(x); i++ {
-		x[i] = uint16(i)
-	}
-
-	// Make a dummy bounds check to prevent the 2 bounds check down below.
-	// The one inside the loop is particularly costly.
-	_ = x[lenS1]
-
-	// Fill in the rest
-	for i := 1; i <= lenS2; i++ {
-		prev := uint16(i)
-		for j := 1; j <= lenS1; j++ {
-			current := x[j-1] // match
-			if s2[i-1] != s1[j-1] {
-				current = min(min(x[j-1]+1, prev+1), x[j]+1)
-			}
-			x[j-1] = prev
-			prev = current
-		}
-		x[lenS1] = prev
-	}
-
-	return int(x[lenS1])
-}
-
-// percentageMatch uses the Levenshtein distance to compute a percentage match
-// between two strings.
-func percentageMatch(expected, actual string) float64 {
-	dist := computeLevenshteinDistance(expected, actual)
-	return 1 - float64(dist/len(expected))
-}
-
-// minPercentageMatch is the minimum percentage that two output operations from
-// being marshaled can match without resulting in a test error. The reason this
-// is used is because we can't always count on the variables being set in the
-// same order on the output string operations. If the variables are ordered
-// differently, the operations are fundamentally the same, but comparison of the
-// two strings will render a false result.
-const minPercentageMatch = 0.95
 
 // TestMarshalQuery tests the MarshalQuery function.
 func TestMarshalQuery(t *testing.T) {
@@ -396,9 +316,16 @@ fieldABC
 				t.Errorf("expected length of output to be %d, got %d", e, a)
 			}
 
-			percentMatch := percentageMatch(trimmedExpectedOutput, trimmedActualOutput)
-			if percentMatch < minPercentageMatch {
-				t.Errorf("expected percentage match to be %f, got %f", minPercentageMatch, percentMatch)
+			if trimmedExpectedOutput != trimmedActualOutput {
+				x := difflib.UnifiedDiff{
+					A:        difflib.SplitLines(trimmedExpectedOutput),
+					B:        difflib.SplitLines(trimmedActualOutput),
+					FromFile: "expected",
+					ToFile:   "actual",
+					Context:  5,
+				}
+				text, _ := difflib.GetUnifiedDiffString(x)
+				t.Fatalf("expected does not match actual:\n%s\n", text)
 			}
 		}
 		t.Run(test.Name, fn)
@@ -698,9 +625,16 @@ fieldABC
 				t.Errorf("expected length of output to be %d, got %d", e, a)
 			}
 
-			percentMatch := percentageMatch(trimmedExpectedOutput, trimmedActualOutput)
-			if percentMatch < minPercentageMatch {
-				t.Errorf("expected percentage match to be %f, got %f", minPercentageMatch, percentMatch)
+			if trimmedExpectedOutput != trimmedActualOutput {
+				x := difflib.UnifiedDiff{
+					A:        difflib.SplitLines(trimmedExpectedOutput),
+					B:        difflib.SplitLines(trimmedActualOutput),
+					FromFile: "expected",
+					ToFile:   "actual",
+					Context:  5,
+				}
+				text, _ := difflib.GetUnifiedDiffString(x)
+				t.Fatalf("expected does not match actual:\n%s\n", text)
 			}
 		}
 		t.Run(test.Name, fn)


### PR DESCRIPTION
- Stabilize marshal output
- feat: Support fallback to json struct tag names

<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This change introduces the ability for `goql` to fall-back to using `json` struct tag field names (via an option). By supporting this, we'll be able to use the models generated by `gqlgen` in our repositories automatically with `goql`, essentially allowing us to get a complete golang GraphQL client "for free" in each service that's using `gqlgen`.


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

No jira for this, I noticed this was missing on my own and I know it'll make a big difference to have this, so I made the change myself.

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
