### PR TITLE
chore: Restencil

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,8 @@
 # syntax, such as anchors, will be fixed automatically.
 version: 2.1
 orbs:
-  shared: getoutreach/shared@2.18.0
-  queue: eddiewebb/queue@1.8.4
+  shared: getoutreach/shared@2.24.0
+  queue: eddiewebb/queue@2.2.1
 
 parameters:
   rebuild_cache:
@@ -115,17 +115,5 @@ workflows:
             branches:
               only:
                 - main
-            tags:
-              only: /v\d+(\.\d+)*(-.*)*/
-      - shared/e2e:
-          context: *contexts
-          ## <<Stencil::Block(circleE2EExtra)>>
-
-          ## <</Stencil::Block>>
-      - shared/docker:
-          context: *contexts
-          filters:
-            branches:
-              ignore: *release_branches
             tags:
               only: /v\d+(\.\d+)*(-.*)*/

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
     # stencil-golang managed dependencies
     ignore:
       - dependency-name: github.com/getoutreach/gobox
+      - dependency-name: github.com/getoutreach/stencil-golang/pkg
       - dependency-name: github.com/getoutreach/services
       - dependency-name: github.com/getoutreach/datastores/v2
       - dependency-name: github.com/getoutreach/mint

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,15 @@
 <!--
   !!!! README !!!! Please fill this out.
 
-  Please follow the PR naming conventions: 
-  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
+  Please follow conventional commit naming conventions:
+
+  https://www.conventionalcommits.org/en/v1.0.0/#summary
 -->
 
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!
 
 <!-- A short description of what your PR does and what it solves. -->
 ## What this PR does / why we need it
-
 
 
 <!-- <<Stencil::Block(jiraPrefix)>> -->
@@ -21,8 +22,6 @@
 
 <!-- Notes that may be helpful for anyone reviewing this PR -->
 ## Notes for your reviewers
-
-
 
 <!-- <<Stencil::Block(custom)>> -->
 

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,9 @@ Pulumi.*.yaml
 # Documentation output
 /apidocs
 
+# Terraform lock files
+.terraform.lock.hcl
+
 ### Start ignores inserted by other modules
 ### End ignores inserted by other modules
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -4,10 +4,10 @@
 # you are reducing compatibility guarantees.
 ## <<Stencil::Block(toolverOverride)>>
 ## <</Stencil::Block>>
-golang 1.19.11
-terraform 1.4.4
+nodejs 18.17.1
 protoc 21.5
-nodejs 18.14.1
+golang 1.21.5
+terraform 1.5.7
 # Note: Versions in this block do not override the default versions above
 # but sometimes you have to declare additional versions of the same tool
 # while leaving the 'default' version intact for the infra.

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -36,16 +36,16 @@
           "to": "/home/dev/app"
         },
         // Maps the go module cache on the host to the persistent volume used by devspaces.
-        // See the value of `go env GOMODCACHE` on the host and devspace.
+        // These should be the respective values of `go env GOMODCACHE`.
         {
-          "from": "${env:HOME}/.asdf/installs/golang/1.19.11/packages/pkg/mod",
-          "to": "/tmp/cache/go/mod/"
+          "from": "${env:HOME}/.asdf/installs/golang/1.21.5/packages/pkg/mod",
+          "to": "/home/dev/.asdf/installs/golang/1.21.5/packages/pkg/mod"
         },
         {
           // Maps the standard library location on the host to the location in the devspace.
           // This enables debugging standard library code.
-          "from": "${env:HOME}/.asdf/installs/golang/1.19.11/go/src",
-          "to": "/home/dev/.asdf/installs/golang/1.19.11/go/src"
+          "from": "${env:HOME}/.asdf/installs/golang/1.21.5/go/src",
+          "to": "/home/dev/.asdf/installs/golang/1.21.5/go/src"
         }
       ]
     },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,6 +14,7 @@
   },
   "go.buildTags": "or_dev",
   "go.testTags": "or_test,or_int,or_e2e",
+  "files.trimTrailingWhitespace": true,
   // This prevents 99% of issues with linters :)
   "editor.formatOnSave": true,
   "shellcheck.customArgs": ["-P", "SCRIPTDIR", "-x"],

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/getoutreach/goql
 go 1.19
 
 require (
-	github.com/getoutreach/gobox v1.71.0
+	github.com/getoutreach/gobox v1.73.2
 	github.com/google/go-cmp v0.5.9
 	github.com/pkg/errors v0.9.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-github.com/getoutreach/gobox v1.71.0 h1:5T3G94y6aG7lqnfzXzMhuR/hw0VnNGwU7VQLml+Lwsw=
-github.com/getoutreach/gobox v1.71.0/go.mod h1:NMFEug44bFUQnpGTS9vov/WsZK36fnQFLDl+3p/yeas=
+github.com/getoutreach/gobox v1.73.2 h1:LDTPzWHj37d/GsYCPJIHHais+f+7aUP8ZS9YuU+qJXU=
+github.com/getoutreach/gobox v1.73.2/go.mod h1:Kx002WFAj+lUVqo7LLxSaQ1w2Mcqg1gefd+qQKr/QGM=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-gotest.tools/v3 v3.4.0 h1:ZazjZUfuVeZGLAmlKKuyv3IKP5orXcwtOwDQH6YVr6o=
+gotest.tools/v3 v3.5.0 h1:Ljk6PdHdOhAb5aDMWXjDLMMhph+BpztA4v1QdqEW2eY=

--- a/scripts/golangci.yml
+++ b/scripts/golangci.yml
@@ -9,18 +9,42 @@ linters-settings:
   govet:
     check-shadowing: true
   revive:
-    confidence: 0
+    rules:
+      # Enable the default golint rules. We must include these because
+      # we configure a single rule, which disables the default rules.
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: error-return
+      - name: error-strings
+      - name: error-naming
+      - name: exported
+      - name: increment-decrement
+      - name: var-naming
+      - name: var-declaration
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: time-naming
+      - name: unexported-return
+      - name: indent-error-flow
+      - name: errorf
+      - name: empty-block
+      - name: superfluous-else
+      - name: unreachable-code
+      - name: redefines-builtin-id
+      # While we agree with this rule, right now it would break too many
+      # projects. So, we disable it by default.
+      - name: unused-parameter
+        disabled: true
   gocyclo:
     min-complexity: 25
-  maligned:
-    suggest-new: true
   dupl:
     threshold: 100
   goconst:
     min-len: 3
     min-occurrences: 3
-  misspell:
-    locale: US
   lll:
     line-length: 140
   gocritic:
@@ -84,7 +108,6 @@ issues:
       linters:
         - gocyclo
         - errcheck
-        - dupl
         - gosec
         - funlen
         - gochecknoglobals # Globals in test files are tolerated.

--- a/service.yaml
+++ b/service.yaml
@@ -1,26 +1,16 @@
 name: goql
-reportingTeam: end-ades
-description: A GraphQL client package written in Go.
-oss: true
-slack: orexservice-notifications
-library: true
-circleAPIKey: ""
-lintroller: bronze
-tracing: honeycomb
-metrics: datadog
-releaseType: semver
-deployTo:
-  environments: []
 arguments:
   circleAPIKey: ""
   commands: []
   ciOptions:
     skipDocker: true
+    skipE2e: true
   commitGuard: false
   dependencies:
     optional: []
     required: []
   description: A GraphQL client package written in Go.
+  go-protoc-imports: []
   grpcClients: []
   kubernetes:
     groups: []
@@ -35,28 +25,53 @@ arguments:
   releaseOptions:
     allowMajorVersions: false
     enablePrereleases: false
+    prereleasesBranch: ""
   reportingTeam: end-ades
   resources: {}
   service: false
+  slack: orexservice-notifications
+  terraform:
+    datadog:
+      grpc:
+        evaluationWindow: ""
+        latency:
+          percentiles:
+            highTraffic: 0
+            lowTraffic: 0
+          thresholds:
+            highTraffic: 0
+            lowTraffic: 0
+        lowTrafficCountThreshold: 0
+        qos:
+          thresholds:
+            highTraffic: 0
+            lowTraffic: 0
+        tags: []
+      http:
+        evaluationWindow: ""
+        percentiles:
+          highTraffic: 0
+          lowTraffic: 0
+        thresholds:
+          highTraffic: 0
+          lowCount: 0
+          lowTraffic: 0
+      pods:
+        thresholds:
+          availableLowCount: 0
   tracing: opentelemetry
   tutorial: false
+  validation: false
   vaultSecrets:
     - deploy/honeycomb_new/%(environment)s/honeycomb
     - deploy/launchdarkly/%(environment)s/launchdarkly
     - deploy/mint/%(environment)s/validation/mint-validator-payload
     - deploy/flagship-shared-secret/%(environment)s/authn-flagship-payload
 modules:
+  - name: github.com/getoutreach/stencil-discovery
+  - name: github.com/getoutreach/stencil-base
+  - name: github.com/getoutreach/stencil-golang
   - name: github.com/getoutreach/stencil-outreach
   - name: github.com/getoutreach/stencil-circleci
   - name: github.com/getoutreach/stencil-actions
-  - name: github.com/getoutreach/stencil-base
-  - name: github.com/getoutreach/stencil-golang
-opsLevel:
-  serviceTier: 0
-  lifecycle: ""
-  confluenceSpaceKey: ""
-  pagerDutyLink: ""
-  datadogDashboards:
-    mainLink: ""
-    custom: []
-  designDocumentLink: ""
+migrated: true

--- a/stencil.lock
+++ b/stencil.lock
@@ -1,26 +1,26 @@
-version: v1.36.0
+version: v1.37.2
 modules:
     - name: github.com/getoutreach/devbase
       url: https://github.com/getoutreach/devbase
-      version: v2.18.0
+      version: v2.24.0
     - name: github.com/getoutreach/stencil-actions
       url: https://github.com/getoutreach/stencil-actions
       version: v0.3.0
     - name: github.com/getoutreach/stencil-base
       url: https://github.com/getoutreach/stencil-base
-      version: v0.12.0
+      version: v0.15.0
     - name: github.com/getoutreach/stencil-circleci
       url: https://github.com/getoutreach/stencil-circleci
-      version: v1.10.0
+      version: v1.12.0
     - name: github.com/getoutreach/stencil-discovery
       url: https://github.com/getoutreach/stencil-discovery
-      version: v1.8.0
+      version: v1.8.1
     - name: github.com/getoutreach/stencil-golang
       url: https://github.com/getoutreach/stencil-golang
-      version: v1.13.2
+      version: v1.18.0
     - name: github.com/getoutreach/stencil-outreach
       url: https://github.com/getoutreach/stencil-outreach
-      version: v0.12.2
+      version: v0.19.1
     - name: github.com/getoutreach/stencil-pipeline
       url: https://github.com/getoutreach/stencil-pipeline
       version: v1.1.0
@@ -76,27 +76,18 @@ files:
     - name: .vscode/settings.json
       template: .vscode/settings.json.tpl
       module: github.com/getoutreach/stencil-golang
-    - name: CONTRIBUTING.md
-      template: CONTRIBUTING.md.tpl
-      module: github.com/getoutreach/stencil-base
     - name: LICENSE
       template: LICENSE.tpl
       module: github.com/getoutreach/stencil-base
     - name: Makefile
       template: Makefile.tpl
       module: github.com/getoutreach/stencil-golang
-    - name: README.md
-      template: README.md.tpl
-      module: github.com/getoutreach/stencil-base
     - name: devenv.yaml
       template: devenv.yaml.tpl
       module: github.com/getoutreach/stencil-golang
     - name: go.mod
       template: go.mod.tpl
       module: github.com/getoutreach/stencil-golang
-    - name: opslevel.yml
-      template: opslevel.yml.tpl
-      module: github.com/getoutreach/stencil-outreach
     - name: package.json
       template: package.json.tpl
       module: github.com/getoutreach/stencil-base


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Fixes the problem where all PR's in this repo would fail due to a step named `ci/circleci: docker` that tried to build a docker image even though this repo is a library, not a service that builds a docker image.

A stencil/bootstrap change 14 months ago added the `docker` ci build step even though this repo doesn't deploy a docker; this repo is only a library. In cases like this, were you have a stenciled repo but you're not building an actual service, you have to disable the CI steps for building a docker container by setting `arguments.ciOptions.skipDocker` to true in the `service.yaml` file _AND THEN_ you have to re-run stencil so stencil will remove the docker steps from `.circleci/config.yml`.

In a [previous PR](https://github.com/getoutreach/goql/pull/106) we added the `ciOptions.skipDocker` but it seems we didn't re-run stencil since the docker steps were still present in the `.circleci/config.yml` file.

This change fixes that broken CI step by restenciling, which removes the `docker` step from CI which was always failing.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

No jira, this just needs to happen

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
